### PR TITLE
Updated x2Go scripts for xubuntu and xfce

### DIFF
--- a/TemplateManagement/Bash/LinuxGraphicalDesktopSetup/XFCE_Xubuntu/ReadMe.md
+++ b/TemplateManagement/Bash/LinuxGraphicalDesktopSetup/XFCE_Xubuntu/ReadMe.md
@@ -1,10 +1,15 @@
 # Introduction
 
-These scripts install the X2Go server for the selected Linux desktop environment (XFCE4 or Xubuntu) on your Linux lab VM.  
+These scripts install XFCE/X2Go and xUbuntu/X2Go graphical desktop environments on Ubuntu.
+
+> [!NOTE]
+> The Ubuntu 16.04, 18.04 and 21.04 LTS images are *no* longer available in the Azure marketplace as a free image provided by Canonical.  Azure Labs only supports using free marketplace images. The instructions/scripts included for Ubuntu 16.04/18.04/21.04 LTS are only applicable to custom lab images that were previously [saved to a Compute Gallery](https://learn.microsoft.com/azure/lab-services/approaches-for-custom-image-creation#save-a-custom-image-from-a-lab-template-virtual-machine), or to custom images that are imported from a [physical lab environment](https://learn.microsoft.com/azure/lab-services/approaches-for-custom-image-creation#bring-a-custom-image-from-a-vhd-in-your-physical-lab-environment).  Otherwise, we recommend using Ubuntu 20.04 or 22.04 LTS which are available as free marketplace images.
 
 ## Ubuntu
 
-These scripts work for both 16.04 LTS and 18.04 LTS.  They will likely work for other versions, but are untested.
+These scripts have been tested with:
+
+    - Ubuntu 16.04/18.04/20.04/21.04/22.04 LTS
 
 ## Configuring X2Go
 
@@ -32,7 +37,6 @@ sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/Azure/LabServices/mai
 ```bash
 sudo sh -c "$(curl -fsSL https://raw.githubusercontent.com/Azure/LabServices/main/TemplateManagement/Bash/LinuxGraphicalDesktopSetup/XFCE_Xubuntu/Ubuntu/x2go-xubuntu.sh)"
 ```
-
 ### Install X2Go Client and Create a Session
 
 Once you have the X2Go\Xrdp server installed on your template VM (using the scripts above), you'll use the X2Go\RDP client to remotely connect to the VM. The X2Go\RDP Client is the application that allows you to connect to a remote server and display a graphical desktop on your local machine.
@@ -40,3 +44,11 @@ Once you have the X2Go\Xrdp server installed on your template VM (using the scri
 Read the following article:
 
 - [Connect to student VM using X2Go](https://docs.microsoft.com/azure/lab-services/how-to-use-remote-desktop-linux-student#connect-to-the-student-vm-using-x2go)
+
+After running the script, you may also want to disable compositing in xUbuntu desktop to optimize performance over a remote desktop connection.  For example, use the below script to disable compositing.  This script requires an active X11 display session, so you will need to run the script via a terminal within your xUbuntu graphical desktop environment by connecting to the VM using X2Go:
+
+```bash
+xfconf-query -c xfwm4 -p /general/use_compositing -s false
+```
+
+Once you've disabled compositing and restarted the VM, you should notice a significant performance improvement when using a remote desktop connection.

--- a/TemplateManagement/Bash/LinuxGraphicalDesktopSetup/XFCE_Xubuntu/Ubuntu/x2go-xfce4.sh
+++ b/TemplateManagement/Bash/LinuxGraphicalDesktopSetup/XFCE_Xubuntu/Ubuntu/x2go-xfce4.sh
@@ -30,13 +30,11 @@ main() {
 
     setup_color
 
-    
     echo "${BLUE}Adding x2go PPA repo...${RESET}"
 
     apt-get install -y software-properties-common
 
     add-apt-repository -y ppa:x2go/stable
-
 
     echo "${BLUE}Updating apt package repository...${RESET}"
 
@@ -44,11 +42,13 @@ main() {
 
     sleep 2
 
-    
     echo "${BLUE}Intalling XFCE4 desktop and x2go server...${RESET}"
 
-    apt-get install -y xfce4 x2goserver x2goserver-xsession
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install xfce4
+    sudo apt install xfce4-session
 
+    # Install x2goserver and x2goserver-xsession packages
+    apt-get install -y x2goserver x2goserver-xsession
 
     echo "${GREEN}XFCE4 desktop and x2go successfully installed!${RESET}"
 }

--- a/TemplateManagement/Bash/LinuxGraphicalDesktopSetup/XFCE_Xubuntu/Ubuntu/x2go-xubuntu.sh
+++ b/TemplateManagement/Bash/LinuxGraphicalDesktopSetup/XFCE_Xubuntu/Ubuntu/x2go-xubuntu.sh
@@ -30,25 +30,26 @@ main() {
 
     setup_color
 
-    
     echo "${BLUE}Adding x2go PPA repo...${RESET}"
 
     apt-get install -y software-properties-common
 
     add-apt-repository -y ppa:x2go/stable
 
-
     echo "${BLUE}Updating apt package repository...${RESET}"
 
     apt-get update
 
     sleep 2
-
     
     echo "${BLUE}Intalling xubuntu desktop and x2go server...${RESET}"
 
-    apt-get install -y xubuntu-desktop x2goserver x2goserver-xsession
+    DEBIAN_FRONTEND=noninteractive apt-get install -y xubuntu-desktop
 
+    echo "${GREEN}Xubuntu desktop and x2go successfully installed!${RESET}"
+
+    # Install x2goserver and x2goserver-xsession packages
+    apt-get install -y x2goserver x2goserver-xsession
 
     echo "${GREEN}Xubuntu desktop and x2go successfully installed!${RESET}"
 }


### PR DESCRIPTION
I've updated the scripts for setting up X2Go with xubuntu and xfce - the current versions *don't* run successfully.  Also, I've added info for xubuntu on how to disable compositing which significantly impacts performance of remote desktop, even with X2Go.  Unfortunately, I can't find a way to include this in the script because it must be run within a terminal within the graphical desktop - I've added a short set of steps at the end of the ReadMe that explains the steps for this.
