### PR TITLE
Added quota increase script for task scheduler and made misc fixes

### DIFF
--- a/LabManagement/PowerShell/BulkOperations/Az.LabServices.BulkOperations.psm1
+++ b/LabManagement/PowerShell/BulkOperations/Az.LabServices.BulkOperations.psm1
@@ -270,6 +270,10 @@ function Import-LabsCsv {
             #Assign to empty array since New-AzLab expects this property to exist, but this property should be optional in the csv
             Add-Member -InputObject $_ -MemberType NoteProperty -Name "Schedules" -Value @() 
         }
+
+        if ((Get-Member -InputObject $_ -Name 'LabOwnerEmails') -and ($_.LabOwnerEmails)) {
+            Write-Warning "LabOwnerEmails is deprecated and has been removed.  If you require this column for scenarios, please log an issue."
+        }
     }
 
     Write-Verbose ($labs | ConvertTo-Json -Depth 40 | Out-String)
@@ -724,7 +728,7 @@ function New-AzLabsBulk {
                         ResourceGroupName = $obj.ResourceGroupName;
                         Location = $obj.Location;
                         Title = $obj.Title;
-                        Description = $obj.LabName;
+                        Description = $obj.Descr;
                         AdminUserPassword = $(ConvertTo-SecureString $obj.Password -AsPlainText -Force);
                         AdminUserUsername = $obj.UserName;
                         AdditionalCapabilityInstallGpuDriver = $obj.GpuDriverEnabled;

--- a/LabManagement/PowerShell/BulkOperations/Az.LabServices.BulkOperations.psm1
+++ b/LabManagement/PowerShell/BulkOperations/Az.LabServices.BulkOperations.psm1
@@ -221,14 +221,6 @@ function Import-LabsCsv {
             Add-Member -InputObject $_ -MemberType NoteProperty -Name "Emails" -Value @() 
         }
 
-        if ((Get-Member -InputObject $_ -Name 'LabOwnerEmails') -and ($_.LabOwnerEmails)) {
-            $_.LabOwnerEmails = ($_.LabOwnerEmails.Split(';')).Trim()
-        }
-        elseif (!(Get-Member -InputObject $_ -Name 'LabOwnerEmails')) {
-            #Assign to empty array since New-AzLab expects this property to exist, but this property should be optional in the csv
-            Add-Member -InputObject $_ -MemberType NoteProperty -Name "LabOwnerEmails" -Value @() 
-        }
-
         if (!(Get-Member -InputObject $_ -Name 'SharedPassword')) {
             Write-Warning "Missing lab's SharedPassword value - defaulting to 'Enabled'.  Column name: SharedPassword."
             Add-Member -InputObject $_ -MemberType NoteProperty -Name "SharedPassword" -Value 'Enabled'
@@ -777,26 +769,6 @@ function New-AzLabsBulk {
                     if ((Get-Member -InputObject $obj -Name 'AadGroupId') -and ($obj.AadGroupId)) {
                         Write-Host "syncing users from AAD ..."
                         Sync-AzLabServicesLabUser -LabName $lab.Name -ResourceGroupName $obj.ResourceGroupName | Out-Null
-                    }
-                    
-                    # If we have any lab owner emails, we need to assign the RBAC permission
-                    if ($obj.LabOwnerEmails) {
-                        Write-Host "Adding Lab Owners: $($obj.LabOwnerEmails) ."
-                        $obj.LabOwnerEmails | ForEach-Object {
-                            # Need to ensure we didn't get an empty string, in case there's an extra delimiter
-                            if ($_) {
-                                # Check if Lab Owner role already exists (the role assignment is added by default by the person who runs the script), if not create it
-                                $userPrincipalName = (Get-AzAdUser -Mail $_).UserPrincipalName
-                                if (-not (Get-AzRoleAssignment -SignInName $userPrincipalName -Scope $currentLab.id -RoleDefinitionName Owner)) {
-                                    New-AzRoleAssignment -SignInName $userPrincipalName -Scope $currentLab.id -RoleDefinitionName Owner | Out-Null
-                                }
-                                # Check if the lab account reader role already exists, if not create it
-                                if (-not (Get-AzRoleAssignment -SignInName $userPrincipalName -ResourceGroupName $obj.ResourceGroupName -ResourceName $obj.LabPlanName -ResourceType "Microsoft.LabServices/LabPlans" -RoleDefinitionName Reader)) {
-                                    New-AzRoleAssignment -SignInName $userPrincipalName -ResourceGroupName $obj.ResourceGroupName -ResourceName $obj.LabPlanName -ResourceType "Microsoft.LabServices/LabPlans" -RoleDefinitionName Reader | Out-Null 
-                                }
-                            }
-                        }
-                        Write-Host "Added Lab Owners: $($obj.LabOwnerEmails)." -ForegroundColor Green
                     }
                 }
                 
@@ -1508,12 +1480,18 @@ function Reset-AzLabUserQuotaBulk {
             }
         }
 
-        $jobs = $aggregateLabs | ForEach-Object {
-                Write-Verbose "From config: $_"
-                Start-ThreadJob -ScriptBlock $block -ArgumentList $_, $PSScriptRoot -Name $_.LabName -ThrottleLimit $ThrottleLimit
-            }
+        Write-Host "Update user quotas."
+        $jobs = @()
 
-        JobManager -currentJobs $jobs -ResultColumnName "ResetQuotaResult"
+        # Stagger starting threads to avoid Azure KeyStore locked error that an occur when too many threads are started in parallel
+        foreach ($config in $aggregateLabs) {
+            Write-Verbose "From config: $config"
+            $jobs += Start-ThreadJob -ScriptBlock $block -ArgumentList $config, $PSScriptRoot -Name ("$($config.LabName)") -ThrottleLimit $ThrottleLimit
+            Start-Sleep -Seconds 1
+        }
+
+        Write-Verbose "Job count: $($jobs.Count)"
+        return JobManager -currentJobs $jobs -ResultColumnName "ResetQuotaResult"
     }
 }
 
@@ -1583,12 +1561,18 @@ function Remove-AzLabUsersBulk {
             }
         }
 
-        $jobs = $aggregateLabs | ForEach-Object {
-                Write-Verbose "From config: $_"
-                Start-ThreadJob -ScriptBlock $block -ArgumentList $_, $PSScriptRoot -Name $_.LabName -ThrottleLimit $ThrottleLimit
-            }
+        Write-Host "Remove lab users."
+        $jobs = @()
 
-        JobManager -currentJobs $jobs -ResultColumnName "RemoveUserResult"
+        # Stagger starting threads to avoid Azure KeyStore locked error that an occur when too many threads are started in parallel
+        foreach ($config in $aggregateLabs) {
+            Write-Verbose "From config: $config"
+            $jobs += Start-ThreadJob -ScriptBlock $block -ArgumentList $config, $PSScriptRoot -Name ("$($config.LabName)") -ThrottleLimit $ThrottleLimit
+            Start-Sleep -Seconds 1
+        }
+
+        Write-Verbose "Job count: $($jobs.Count)"
+        return JobManager -currentJobs $jobs -ResultColumnName "RemoveUserResult"
     }
 }
 
@@ -1758,14 +1742,17 @@ function Add-AzLabsUsersBulk {
 
             Write-Host "Adding users to lab.  This may take awhile."
             $jobs = @()
-
-            $ConfigObject | ForEach-Object {
-            Write-Verbose "From config: $_"
-                $jobs += Start-ThreadJob  -InitializationScript $init -ScriptBlock $block -ArgumentList $PSScriptRoot -InputObject $_ -Name ("$($_.ResourceGroupName)+$($_.LabPlanName)+$($_.LabName)") -ThrottleLimit $ThrottleLimit
+ 
+            # Stagger starting threads to avoid Azure KeyStore locked error that an occur when too many threads are started in parallel
+            foreach ($config in $ConfigObject) {
+                Write-Verbose "From config: $config"
+                $jobs += Start-ThreadJob  -InitializationScript $init -ScriptBlock $block -ArgumentList $PSScriptRoot -Name ("$($config.ResourceGroupName)+$($config.LabPlanName)+$($config.LabName)") -ThrottleLimit $ThrottleLimit
+                Start-Sleep -Seconds 1
             }
-
-            return JobManager -currentJobs $jobs -ResultColumnName "AddUserResult" -ConfigObject $ConfigObject
-         }
+ 
+            Write-Verbose "Job count: $($jobs.Count)"
+            return JobManager -currentJobs $jobs -ResultColumnName "AddUserResult" ConfigObject $ConfigObject
+        }
 
          Add-AzLabsUser-Jobs -ConfigObject $aggregateLabs 
     }
@@ -1917,7 +1904,6 @@ function Confirm-AzLabsBulk {
                         Write-Error "Unexpected number of VMs in succeeded state"
                     }
                 }
-        
             }
 
             $jobs = @()

--- a/LabManagement/PowerShell/BulkOperations/Examples/Create-Publish-AzLabs.ps1
+++ b/LabManagement/PowerShell/BulkOperations/Examples/Create-Publish-AzLabs.ps1
@@ -1,0 +1,44 @@
+[CmdletBinding()]
+param(
+    [parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+    [string]
+    $CsvConfigFile,
+
+    [parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+    [string]
+    $CsvOutputFile,
+
+    [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+    [ValidateNotNullOrEmpty()]
+    [switch] $force,
+
+    [parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+    [int]
+    $ThrottleLimit = 10
+)
+
+# Make sure the input file does exist
+if (-not (Test-Path -Path $CsvConfigFile)) {
+    Write-Error "Input CSV File must exist, please choose a valid file location..."
+}
+
+# Make sure the output file doesn't exist
+if ((Test-Path -Path $CsvOutputFile) -and (-not $force.IsPresent)) {
+    Write-Error "Output File cannot already exist, please choose a location to create a new output file..."
+}
+
+$outerScriptstartTime = Get-Date
+Write-Host "Executing Lab Creation Script, starting at $outerScriptstartTime" -ForegroundColor Green
+
+Import-Module ../Az.LabServices.BulkOperations.psm1 -Force
+
+$labPlanResults = $CsvConfigFile | 
+        Import-LabsCsv |                                      # Import the CSV File into objects, including validation & transforms
+        New-AzLabsBulk -ThrottleLimit $ThrottleLimit |        # Create all labs
+        Publish-AzLabsBulk -ThrottleLimit $ThrottleLimit      # Publish all the labs
+
+# Write out the results
+$labPlanResults | Export-LabsCsv -CsvConfigFile $CsvOutputFile -Force:$force.IsPresent
+$labPlanResults | Select-Object -Property ResourceGroupName, LabPlanName, LabName, LabPlanResult, LabResult, PublishResult | Format-Table
+
+Write-Host "Completed running Bulk Lab Creation script, total duration $(((Get-Date) - $outerScriptstartTime).TotalMinutes) minutes" -ForegroundColor Green

--- a/LabManagement/PowerShell/BulkOperations/Readme.md
+++ b/LabManagement/PowerShell/BulkOperations/Readme.md
@@ -81,7 +81,7 @@ NonAdminUserName  | Username for optional non-admin account.
 NonAdminPassword  | Password for optional non-admin account.
 LinuxRdp          | Set to "True" if the Virtual Machine requires Linux RDP, otherwise "False".
 Emails            | Semicolon separated string of student emails to be added to the lab.  For example:  "bob@test.com;charlie@test.com"
-LabOwnerEmails    | Semicolon separated string of teacher emails to be added to the lab.  The teacher will get Owner rights to the lab, and Reader rights to the Lab Account.  NOTE: this account must exist in Azure Active Directory tenant.
+LabOwnerEmails    | [DEPRECATED] This column is no longer supported; if you need support for this column, please log an issue.
 Invitation        | Note to include in the invitation email to students.  If you leave this field blank, invitation emails won't be sent during lab creation.
 Schedules         | The name of the csv file that contains the schedule for this class.  For example: "charms.csv".  If left blank, a schedule won't be applied.
 TemplateVmState   | Enabled\Disabled values indicate whether the lab should have a template VM created.
@@ -108,8 +108,8 @@ When you use the bulk deployment script to create labs, you must specify either 
 
 For the **Default VM sizes**, the following table shows the mapping between the friendly name shown in the portal and the underlying VM SKU Name/Size expected by the API.
 
-Friendly Name (shown in portal)| Underlying VM SKU Name | Underlying VM SKU Size           
--------------------------------|---------------------------------------------------------
+Friendly Name (shown in portal)| Underlying VM SKU Name | Underlying VM SKU Size
+-------------------------------|------------------------|--------------------------------
 Small                          | Basic                  | Fsv2_2_4GB_128_S_SSD
 Medium                         | Standard               | Fsv2_4_8GB_128_S_SSD
 Medium (nested virtualization) | Virtualization         | Dsv4_4_16GB_128_P_SSD

--- a/LabManagement/PowerShell/BulkOperations/Readme.md
+++ b/LabManagement/PowerShell/BulkOperations/Readme.md
@@ -73,7 +73,7 @@ UsageQuota        | Maximum quota per student.
 UsageMode         | Type of usage expected for the lab.  Either "Restricted" - only those who are registered in the lab, or "Open" anyone.
 SharedPassword    | Enabled\Disabled values indicate whether the lab should use a shared password.  "Enabled" means the lab uses a single shared password for the student's virtual machines, "Disabled" means the students will be prompted to change their password on first login.
 Size              | The Virtual Machine size to use for the Lab. Please see details below on how these map to the Azure Portal.
-Title             | The title for the lab.
+Title             | The title for the lab.  This is the value that the students/teachers will see for the name of the lab in the labs.azure.com portal.
 Descr             | The description for the lab.
 UserName          | The default username for admin account.
 Password          | The default password for admin account.

--- a/LabManagement/PowerShell/JITUserQuota/JITQuotaWithManagedId.ps1
+++ b/LabManagement/PowerShell/JITUserQuota/JITQuotaWithManagedId.ps1
@@ -11,7 +11,7 @@ $excludeLabs = @('*test*','*demo*','*training*', '*how to*')
 # Number of available hours we reset the student to when running this script
 $usageQuota = 9
 
-# Segment of labs to update based on lab accounts, regular expression to match
+# Segment of labs to update based on lab plans, regular expression to match
 
 # Match for all lab plans
 $labPlanNameRegex = "^.*"
@@ -77,7 +77,8 @@ try {
         }
         if ($toExclude) 
             {
-                Write-Output "   Excluding Lab '$labName'" 6>> $HostOutputFile.FullName
+                # Can't write output to the hostfile because it breaks the filtering, so we'll just write to the terminal
+                Write-Host "excluding $labName "
                 $false
             } 
         else {$true}

--- a/LabManagement/PowerShell/JITUserQuota/JITQuotaWithRunAs.ps1
+++ b/LabManagement/PowerShell/JITUserQuota/JITQuotaWithRunAs.ps1
@@ -14,7 +14,7 @@ $excludeLabs = @('*test*','*demo*','*training*', '*how to*')
 # Number of available hours we reset the student to when running this script
 $usageQuota = 8
 
-# Segment of labs to update based on lab accounts, regular expression to match
+# Segment of labs to update based on lab plans, regular expression to match
 
 # Match for all lab plans
 $labPlanNameRegex = "^.*"
@@ -71,7 +71,8 @@ try {
         }
         if ($toExclude) 
             {
-                Write-Output "   Excluding Lab '$labName'" 6>> $HostOutputFile.FullName
+                # Can't write output to the hostfile because it breaks the filtering, so we'll just write to the terminal
+                Write-Host "excluding $labName "
                 $false
             } 
         else {$true}

--- a/LabManagement/PowerShell/JITUserQuota/JITQuotaWithScheduledTask.ps1
+++ b/LabManagement/PowerShell/JITUserQuota/JITQuotaWithScheduledTask.ps1
@@ -36,7 +36,7 @@ if (-not (Get-Command -Name "Get-AzLabServicesLab" -ErrorAction SilentlyContinue
 Import-Module Az
 Import-Module "..\BulkOperations\Az.LabServices.BulkOperations.psm1" -Force
     
-#Connect-AzAccount -Subscription $subId -Identity
+Connect-AzAccount -Subscription $subId -Identity
 Write-Output "Lab quota update start at $(Get-Date)"
 
 # create a temp file for host output

--- a/LabManagement/PowerShell/JITUserQuota/JITQuotaWithScheduledTask.ps1
+++ b/LabManagement/PowerShell/JITUserQuota/JITQuotaWithScheduledTask.ps1
@@ -34,8 +34,19 @@ if (-not (Get-Command -Name "Get-AzLabServicesLab" -ErrorAction SilentlyContinue
 }
 
 Import-Module Az
-Import-Module "..\BulkOperations\Az.LabServices.BulkOperations.psm1" -Force
-    
+
+$relativePath = "..\BulkOperations\Az.LabServices.BulkOperations.psm1"
+$currentDirPath = Join-Path -Path (Get-Location) -ChildPath "Az.LabServices.BulkOperations.psm1"
+
+if (Test-Path -Path $relativePath) {
+    Import-Module $relativePath -Force
+} elseif (Test-Path -Path $currentDirPath) {
+    Import-Module $currentDirPath -Force
+} else {
+    Write-Error "BulkOperations.psm1 not found in the provided relative path or the current directory."
+    return
+}
+
 Connect-AzAccount -Subscription $subId -Identity
 Write-Output "Lab quota update start at $(Get-Date)"
 

--- a/LabManagement/PowerShell/JITUserQuota/JITQuotaWithScheduledTask.ps1
+++ b/LabManagement/PowerShell/JITUserQuota/JITQuotaWithScheduledTask.ps1
@@ -1,0 +1,100 @@
+# Lets stop the script for any errors
+$ErrorActionPreference = "Stop"
+
+# ************************************************
+# ************ FIELDS TO UPDATE ******************
+# ************************************************
+
+# List of lab names that we should not include when updating quota)
+$excludeLabs = @('*test*','*demo*','*training*', '*how to*')
+
+# Number of available hours we reset the student to when running this script
+$usageQuota = 8
+
+# Segment of labs to update based on lab plans, regular expression to match
+
+# Match for all lab plans   
+$labPlanNameRegex = "^.*"
+
+# Subscription ID
+$subId = "1111-1111-1111-11111-11111111"
+
+# ************************************************
+
+if ($PSVersionTable.PSEdition -eq 'Desktop' -and (Get-Module -Name AzureRM -ListAvailable)) {
+    #    Write-Warning -Message ('Az module not installed. Having both the AzureRM and ' +
+    #      'Az modules installed at the same time is not supported.')
+    } else {
+        Install-Module -Name Az -AllowClobber -Scope CurrentUser -Force -Confirm:$false
+    }
+
+# Install the Az.LabServices module if the command isn't available
+if (-not (Get-Command -Name "Get-AzLabServicesLab" -ErrorAction SilentlyContinue)) {
+    Install-Module -Name Az.LabServices -Scope CurrentUser -Force
+}
+
+Import-Module Az
+Import-Module "..\BulkOperations\Az.LabServices.BulkOperations.psm1" -Force
+    
+#Connect-AzAccount -Subscription $subId -Identity
+Write-Output "Lab quota update start at $(Get-Date)"
+
+# create a temp file for host output
+$dateString = Get-Date -Format "yyyyMMdd_HHmmss"
+$tempFilePath = Join-Path -Path $env:TEMP -ChildPath "AzureLabsUserQuota_$dateString.txt"
+$hostOutputFile = New-Item -Path $tempFilePath -ItemType File -Force
+
+$labPlans = Get-AzLabServicesLabPlan | Where-Object {
+    $_.Name -match $labPlanNameRegex
+}
+Write-Output " Found .. $(($labPlans | Measure-Object).Count) lab plans)"
+
+Write-Output "  Temp file location is: $($HostOutputFile.FullName)"
+
+try {
+    $scriptstartTime = Get-Date
+    Write-Output "Executing Bulk User Quota Script, starting at $scriptstartTime"
+
+    $labPlans = Get-AzLabServicesLabPlan | Where-Object {
+        $_.Name -match $labPlanNameRegex
+    }
+    
+    $labs = $labPlans | Get-AzLabServicesLab 6>> $HostOutputFile.FullName
+
+    # Filter the labs down to only the set that we should update
+    Write-Output "Checking for labs to exclude..." 6>> $HostOutputFile.FullName
+    $labsToUpdate = $labs | Where-Object {
+        $toExclude = $null
+        $labName = $_.Name
+        $toExclude = $excludeLabs | ForEach-Object {
+            if ($labName -like $_) {$true}
+        }
+        if ($toExclude) 
+            {
+                # Can't write output to the hostfile because it breaks the filtering, so we'll just write to the terminal
+                Write-Host "excluding $labName "
+                $false
+            } 
+        else {$true}
+    }
+
+    $labsToUpdate | ForEach-Object {
+		Write-Output "Add member $($_.Name)"
+        Add-Member -InputObject $_ -MemberType NoteProperty -Name "UsageQuota" -Value $usageQuota -Force
+        Add-Member -InputObject $_ -MemberType NoteProperty -Name "LabName" -Value $_.Name -Force
+        Add-Member -InputObject $_ -MemberType NoteProperty -Name "ResourceGroupName" -Value $_.Id.Split("/")[4] -Force
+    }
+
+    # Now - let's call the bulk update function to update all the labs, piping 'host' messages to a file
+    $labsToUpdate | Reset-AzLabUserQuotaBulk -ThrottleLimit 5  6>> $hostOutputFile.FullName
+}
+catch {
+    # We just rethrow any errors with original context
+    throw
+}
+finally {
+    # Read in the 'host' messages and show them in the output
+    Get-Content -Path $hostOutputFile.FullName
+}
+
+Write-Output "Completed running Bulk User Quota script, total duration $([math]::Round(((Get-Date) - $scriptstartTime).TotalMinutes, 1)) minutes"

--- a/LabManagement/PowerShell/JITUserQuota/readme.md
+++ b/LabManagement/PowerShell/JITUserQuota/readme.md
@@ -3,10 +3,18 @@
 
 Sample that creates a just-in-time system to update a lab user's quota as needed.
 
-## Setup with Managed Identity
+## Setup with Managed Identity and Runbook
 
 - **Setup Automation account with runbook using Managed identity**.  See [Tutorial: Create Automation PowerShell runbook using managed identity](https://docs.microsoft.com/azure/automation/learn/powershell-runbook-managed-identity) for details
 - **Setup modules**.  Add Az.LabServices.BulkOperations.psm1 as Az.LabServices.BulkOperations.zip
 - **Add Runbook PowerShell code**.  Copy the JITQuotaWithManagedId.ps1 into the runbook editor
 - **Publish to Runbook**.  See [managing runbooks](https://learn.microsoft.com/azure/automation/manage-runbooks#publish-a-runbook) for details.
 - **Set schedule**.  See [managing runbooks](https://learn.microsoft.com/azure/automation/manage-runbooks#schedule-a-runbook-in-the-azure-portal) for details.
+
+## Setup with Managed Identity and Windows Task Scheduler
+To run this script, it assumes that this repo has been cloned to the VM because it relies on the Az.LabServices.BulkOperations.psm1 script.
+
+- **Setup Managed Identity on VM**.  The JITQuotaWithScheduledTask.psm1 script is designed to be run via Windows Task Scheduler on a dedicated Azure VM that has Managed Identity configured. See [configure managed identities](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/qs-configure-portal-windows-vm) to configure Managed Identity for the VM.
+- **Setup modules**.  The script automatically installs and imports the AZ and Az.LabServicesBulkOperations.psm1 modules.
+- **Setup Windows Task Scheduler**.  Use Windows Task Scheduler to schedule the script to run on regular cadence, such as the start of each week.
+


### PR DESCRIPTION
1.) Added version of the quota increase script that is decoupled from using a runbook, so that it can be used with task scheduler (which is a scenario used by some customers)

2.) Fixed issue in quota scripts where the exclude labs filter was writing to the hostfile - this essentially caused the filter to no-op so that all labs were still returned.

3.) Updated ReadMes

4.) In the bulk deployment script, removed support for LabOwners column because it doesn't work - deprecating this column.  If we find out customers rely on this, we recommend logging issue.  Also, fixed places where we were creating thread jobs without sleeping/staggering which was causing an Azure Key Store error.